### PR TITLE
LABX-270 SC downgrade to solc v0.4.21

### DIFF
--- a/contracts/BalanceHolder.sol
+++ b/contracts/BalanceHolder.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-shared-lib/contracts/ERC20Interface.sol";
@@ -11,7 +11,7 @@ import "./adapters/Roles2LibraryAdapter.sol";
 
 contract BalanceHolder is Roles2LibraryAdapter {
 
-    constructor(address _roles2Library)
+    function BalanceHolder(address _roles2Library)
     Roles2LibraryAdapter(_roles2Library)
     public
     {

--- a/contracts/BoardController.sol
+++ b/contracts/BoardController.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -98,7 +98,7 @@ contract BoardController is StorageAdapter, MultiEventsHistoryAdapter, Roles2Lib
         _;
     }
 
-    constructor(
+    function BoardController(
         Storage _store,
         bytes32 _crate,
         address _roles2Library

--- a/contracts/ContractsManager.sol
+++ b/contracts/ContractsManager.sol
@@ -3,7 +3,7 @@
 * Licensed under the AGPL Version 3 license.
 */
 
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 
 import "solidity-shared-lib/contracts/Owned.sol";
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -27,7 +27,7 @@ contract ContractsManager is Owned, StorageAdapter, Roles2LibraryAdapter {
     /**
     *  @notice Constructor that sets `storage` and `crate` to given values.
     */
-    constructor(Storage _store, bytes32 _crate, address _roles2Library)
+    function ContractsManager(Storage _store, bytes32 _crate, address _roles2Library)
     public
     StorageAdapter(_store, _crate)
     Roles2LibraryAdapter(_roles2Library)

--- a/contracts/IPFSLibrary.sol
+++ b/contracts/IPFSLibrary.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -17,7 +17,7 @@ contract IPFSLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Library
 
     StorageInterface.AddressBytes32Bytes32Mapping ipfsHashes;
 
-    constructor(
+    function IPFSLibrary(
         Storage _store,
         bytes32 _crate,
         address _roles2Library

--- a/contracts/JobController.sol
+++ b/contracts/JobController.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -131,7 +131,7 @@ contract JobController is JobDataCore, MultiEventsHistoryAdapter, Roles2LibraryA
         _;
     }
 
-    constructor(
+    function JobController(
         Storage _store,
         bytes32 _crate,
         address _roles2Library

--- a/contracts/JobDataCore.sol
+++ b/contracts/JobDataCore.sol
@@ -90,7 +90,7 @@ contract JobDataCore is StorageAdapter, BitOps {
     // At which state job has been marked as FINALIZED
     StorageInterface.UIntUIntMapping jobFinalizedAt;
 
-    constructor(
+    function JobDataCore(
         Storage _store,
         bytes32 _crate
     )

--- a/contracts/JobsDataProvider.sol
+++ b/contracts/JobsDataProvider.sol
@@ -17,7 +17,7 @@ interface BoardControllerAccessor {
 
 contract JobsDataProvider is JobDataCore {
 
-    constructor(
+    function JobsDataProvider(
         Storage _store,
         bytes32 _crate
     )

--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -13,7 +13,7 @@ contract Migrations {
         if (msg.sender == owner) _;
     }
 
-    constructor() public {
+    function Migrations() public {
         owner = msg.sender;
     }
 

--- a/contracts/MultiEventsHistory.sol
+++ b/contracts/MultiEventsHistory.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.4.18;
 
-import './adapters/Roles2LibraryAdapter.sol';
+import "./adapters/Roles2LibraryAdapter.sol";
 
 
 /**
@@ -21,7 +21,7 @@ contract MultiEventsHistory is Roles2LibraryAdapter {
     // Authorized calling contracts.
     mapping(address => bool) public isAuthorized;
 
-    constructor(address _roles2Library) public Roles2LibraryAdapter(_roles2Library) {}
+    function MultiEventsHistory(address _roles2Library) public Roles2LibraryAdapter(_roles2Library) {}
 
     /**
      * Authorize new caller contract.

--- a/contracts/PaymentGateway.sol
+++ b/contracts/PaymentGateway.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
 import "./adapters/MultiEventsHistoryAdapter.sol";
@@ -42,7 +42,7 @@ contract PaymentGateway is StorageAdapter, MultiEventsHistoryAdapter, Roles2Libr
     StorageInterface.Address feeAddress;
     StorageInterface.UInt fees; // 10000 is 100%.
 
-    constructor(
+    function PaymentGateway(
         Storage _store,
         bytes32 _crate,
         address _roles2Library

--- a/contracts/PaymentProcessor.sol
+++ b/contracts/PaymentProcessor.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.4.18;
 
-import './adapters/Roles2LibraryAdapter.sol';
+import "./adapters/Roles2LibraryAdapter.sol";
 
 
 contract PaymentGatewayInterface {
@@ -39,7 +39,7 @@ contract PaymentProcessor is Roles2LibraryAdapter {
         }
     }
 
-    constructor(address _roles2Library) public Roles2LibraryAdapter(_roles2Library) {}
+    function PaymentProcessor(address _roles2Library) public Roles2LibraryAdapter(_roles2Library) {}
 
 
     // Only contract owner

--- a/contracts/RatingsAndReputationLibrary.sol
+++ b/contracts/RatingsAndReputationLibrary.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -158,7 +158,7 @@ contract RatingsAndReputationLibrary is StorageAdapter, MultiEventsHistoryAdapte
       _;
     }
 
-    constructor(
+    function RatingsAndReputationLibrary(
 		Storage _store, 
 		bytes32 _crate, 
 		address _roles2Library

--- a/contracts/Recovery.sol
+++ b/contracts/Recovery.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "./User.sol";
@@ -16,7 +16,7 @@ contract Recovery is Roles2LibraryAdapter {
 
     event UserRecovered(address prevUser, address newUser, User userContract);
 
-    constructor(address _roles2Library) Roles2LibraryAdapter(_roles2Library) public {}
+    function Recovery(address _roles2Library) Roles2LibraryAdapter(_roles2Library) public {}
 
     function recoverUser(User _userContract, address _newAddress) auth public returns (uint) {
         address prev = _userContract.contractOwner();

--- a/contracts/Roles2Library.sol
+++ b/contracts/Roles2Library.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -39,7 +39,7 @@ contract Roles2Library is StorageAdapter, MultiEventsHistoryAdapter, Owned {
         _;
     }
 
-    constructor(Storage _store, bytes32 _crate) StorageAdapter(_store, _crate) public {
+    function Roles2Library(Storage _store, bytes32 _crate) StorageAdapter(_store, _crate) public {
         rootUsers.init('rootUsers');
         userRoles.init('userRoles');
         capabilityRoles.init('capabilityRoles');

--- a/contracts/SkillsLibrary.sol
+++ b/contracts/SkillsLibrary.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -67,7 +67,7 @@ contract SkillsLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Libra
         return _flag & 0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa == 0;
     }
 
-    constructor(
+    function SkillsLibrary(
         Storage _store, 
         bytes32 _crate, 
         address _roles2Library

--- a/contracts/StorageManager.sol
+++ b/contracts/StorageManager.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.21;
 
 import "solidity-storage-lib/contracts/BaseStorageManager.sol";
 import "./adapters/MultiEventsHistoryAdapter.sol";

--- a/contracts/User.sol
+++ b/contracts/User.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-shared-lib/contracts/Owned.sol";
@@ -24,7 +24,7 @@ contract User is Owned {
         }
     }
 
-    constructor(address _owner, address _recoveryContract) public {
+    function User(address _owner, address _recoveryContract) public {
         userProxy = new UserProxy();
         recoveryContract = _recoveryContract;
         contractOwner = _owner;

--- a/contracts/UserFactory.sol
+++ b/contracts/UserFactory.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "./User.sol";
@@ -31,7 +31,7 @@ contract UserFactory is MultiEventsHistoryAdapter, Roles2LibraryAdapter {
     mapping(uint8 => uint8) internal indexToRoles;
     uint8 internal allowedRolesCount;
 
-    constructor(address _roles2Library) Roles2LibraryAdapter(_roles2Library) public {}
+    function UserFactory(address _roles2Library) Roles2LibraryAdapter(_roles2Library) public {}
 
     function setupEventsHistory(address _eventsHistory) auth external returns (uint) {
         require(_eventsHistory != 0x0);
@@ -99,7 +99,7 @@ contract UserFactory is MultiEventsHistoryAdapter, Roles2LibraryAdapter {
         require(_owner != 0x0);
 
         for (uint _roleIdx = 0; _roleIdx < _roles.length; ++_roleIdx) {
-            require(allowedRoles[_roles[_roleIdx]], "Should provide only allowed roles");
+            require(allowedRoles[_roles[_roleIdx]]);
         }
 
         User user = new User(_owner, _recoveryContract);

--- a/contracts/UserLibrary.sol
+++ b/contracts/UserLibrary.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 import "solidity-storage-lib/contracts/StorageAdapter.sol";
@@ -82,7 +82,7 @@ contract UserLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Library
         _;
     }
 
-    constructor(
+    function UserLibrary(
         Storage _store, 
         bytes32 _crate, 
         address _roles2Library
@@ -291,10 +291,10 @@ contract UserLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Library
     view 
     returns (uint _count, uint _userIdx)
     {
-        require(_categories.length == _skills.length, "Invalid categories and skills array lengths");
+        require(_categories.length == _skills.length);
 
         uint _usersCount = getUsersCount();
-        require(_fromIdx < _usersCount, "Invalid fromIdx value");
+        require(_fromIdx < _usersCount);
 
         _maxLen = (_fromIdx + _maxLen <= _usersCount) ? _maxLen : (_usersCount - _fromIdx);
 
@@ -341,7 +341,7 @@ contract UserLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Library
         uint _userCategories = store.get(skillCategories, _user, _area);
         for (uint _categoryIdx = 0; _categoryIdx < _categories.length; ++_categoryIdx) {
             uint _category = _categories[_categoryIdx];
-            require(_isValidAreaOrCategory(_category), "Invalid category");
+            require(_isValidAreaOrCategory(_category));
             
             uint _userCategory = _userCategories & _getAreaOrCategoryBits(_category);
 
@@ -381,7 +381,7 @@ contract UserLibrary is StorageAdapter, MultiEventsHistoryAdapter, Roles2Library
         uint _userCategories = store.get(skillCategories, _user, _area);
         for (uint _categoryIdx = 0; _categoryIdx < _categories.length; ++_categoryIdx) {
             uint _category = _categories[_categoryIdx];
-            require(_isValidAreaOrCategory(_category), "Invalid category");
+            require(_isValidAreaOrCategory(_category));
             
             uint _userCategory = _userCategories & _getAreaOrCategoryBits(_category);
 

--- a/contracts/UserProxy.sol
+++ b/contracts/UserProxy.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 import "solidity-shared-lib/contracts/Owned.sol";
 

--- a/contracts/adapters/MultiEventsHistoryAdapter.sol
+++ b/contracts/adapters/MultiEventsHistoryAdapter.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 /**
  * @title General MultiEventsHistory user.

--- a/contracts/adapters/Roles2LibraryAdapter.sol
+++ b/contracts/adapters/Roles2LibraryAdapter.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 
 contract Roles2LibraryInterface {
@@ -29,7 +29,7 @@ contract Roles2LibraryAdapter {
         _;
     }
 
-    constructor(address _roles2Library) public {
+    function Roles2LibraryAdapter(address _roles2Library) public {
         roles2Library = Roles2LibraryInterface(_roles2Library);
     }
 

--- a/contracts/helpers/Mock.sol
+++ b/contracts/helpers/Mock.sol
@@ -3,7 +3,7 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-pragma solidity ^0.4.18;
+pragma solidity ^0.4.21;
 
 contract Mock {
 

--- a/migrations/21_init_userfactory.js
+++ b/migrations/21_init_userfactory.js
@@ -5,8 +5,13 @@ const MultiEventsHistory = artifacts.require('./MultiEventsHistory.sol');
 
 module.exports = deployer => {
     const UserFactoryRole = 20;
+    const UserRoles = {
+        WORKER: 1,
+        CLIENT: 2,
+        RECRUITER: 3,
+    }
     let userFactory;
-    let rolesLibrary;
+    let rolesLibrary; 
 
     deployer
     .then(() => Roles2Library.deployed())
@@ -16,10 +21,15 @@ module.exports = deployer => {
     .then(() => userFactory.setupEventsHistory(MultiEventsHistory.address))
     .then(() => MultiEventsHistory.deployed())
     .then(multiEventsHistory => multiEventsHistory.authorize(UserFactory.address))
-    .then(() => {
+    .then(async () => {
         let sig = rolesLibrary.contract.addUserRole.getData(0,[0]).slice(0, 10);
-        return rolesLibrary.addRoleCapability(UserFactoryRole, Roles2Library.address, sig);
+        await rolesLibrary.addRoleCapability(UserFactoryRole, Roles2Library.address, sig);
     })
     .then(() => rolesLibrary.addUserRole(UserFactory.address, UserFactoryRole))
+    .then(async () => {
+        const userFactory = await UserFactory.deployed()
+        await userFactory.addAllowedRoles([UserRoles.WORKER, UserRoles.CLIENT, UserRoles.RECRUITER])
+    })
+
     .then(() => console.log("[Migration] UserFactory #initialized"))
 };

--- a/migrations/40_set_moderator_role.js
+++ b/migrations/40_set_moderator_role.js
@@ -1,18 +1,22 @@
 "use strict";
 const BoardController = artifacts.require('./BoardController.sol');
 const Roles2Library = artifacts.require('./Roles2Library.sol');
+const Recovery = artifacts.require('Recovery')
 
 module.exports = deployer => {
     deployer.then(async () => {
         const boardController = await BoardController.deployed();
         const roles2Library = await Roles2Library.deployed();
+        const recovery = await Recovery.deployed();
 
         const ModeratorRole = 10;
         const createBoardSig = boardController.contract.createBoard.getData(0,0,0,0).slice(0,10);
         const closeBoardSig = boardController.contract.closeBoard.getData(0).slice(0,10);
+        const recoverUserSig = recovery.contract.recoverUser.getData(0x0, 0x0).slice(0,10);
 
         await roles2Library.addRoleCapability(ModeratorRole, BoardController.address, createBoardSig);
         await roles2Library.addRoleCapability(ModeratorRole, BoardController.address, closeBoardSig);
+        await roles2Library.addRoleCapability(ModeratorRole, Recovery.address, recoverUserSig);
 
         console.log("[Migration] Moderator Role #setup")
 	})

--- a/package.json
+++ b/package.json
@@ -29,14 +29,13 @@
   "dependencies": {
     "abi-decoder": "^1.0.9",
     "bluebird": "^3.5.0",
-    "solidity-storage-lib": "chronobank/solidity-storage-lib",
-    "truffle-hdwallet-provider": "mikefluff/truffle-hdwallet-provider"
+    "solidity-storage-lib": "alesanro/solidity-storage-lib#downgrade-solc-0.4.21",
+    "truffle-hdwallet-provider": "mikefluff/truffle-hdwallet-provider#7a2eccca1ba17c235a3ef258914ca74ea5f13014"
   },
   "devDependencies": {
     "ganache-cli": "^6.1.0",
-    "truffle": "4.1.7",
+    "truffle": "4.1.5",
     "babel-polyfill": "^6.26.0",
-    "truffle-hdwallet-provider": "mikefluff/truffle-hdwallet-provider#7a2eccca1ba17c235a3ef258914ca74ea5f13014",
     "standard-version": "^4.0.0"
   }
 }

--- a/test/userFactory.js
+++ b/test/userFactory.js
@@ -92,9 +92,20 @@ contract('UserFactory', function(accounts) {
       await helpers.assertExpectations(mock)()
     })
 
+    it("should have pre-installed roles for client, worker and recruiter", async () => {
+      const gotRoles = await userFactory.getAllowedRoles()
+      const Roles = {
+        CLIENT: 1,
+        WORKER: 2,
+        RECRUITER: 3,
+      }
+      assert.equal(gotRoles.toString(), [ Roles.CLIENT, Roles.WORKER, Roles.RECRUITER, ].toString())
+    })
+
     it("should add roles to allowed roles", async () => {
       const caller = accounts[0]
       const roles = [ 10,20, ]
+      const gotRoles = await userFactory.getAllowedRoles()
 
       await userFactory.setRoles2Library(Mock.address)
       await mock.expect(
@@ -109,7 +120,7 @@ contract('UserFactory', function(accounts) {
       )
       await userFactory.addAllowedRoles(roles, { from: caller, })
       await helpers.assertExpectations(mock)()
-      assert.equal((await userFactory.getAllowedRoles.call()).toString(), roles.toString())
+      assert.equal((await userFactory.getAllowedRoles.call()).toString(), Array.prototype.concat.apply(gotRoles, roles).toString())
     })
 
     it("should remove roles from allowed roles", async () => {
@@ -117,6 +128,7 @@ contract('UserFactory', function(accounts) {
       const ROLE1 = 10
       const ROLE2 = 20
       const roles = [ ROLE1, ROLE2, ]
+      const gotRoles = await userFactory.getAllowedRoles()
 
       await userFactory.setRoles2Library(Mock.address)
       await mock.expect(
@@ -142,7 +154,7 @@ contract('UserFactory', function(accounts) {
       )
       await userFactory.removeAllowedRoles([ROLE1], { from: caller, })
       await helpers.assertExpectations(mock)()
-      assert.equal((await userFactory.getAllowedRoles.call()).toString(), [ROLE2].toString())
+      assert.equal((await userFactory.getAllowedRoles.call()).toString(), Array.prototype.concat.apply(gotRoles,[ROLE2]).toString())
     })
   });
 
@@ -178,7 +190,7 @@ contract('UserFactory', function(accounts) {
     it('should THROW if failed to set roles', async () => {
       const caller = accounts[1];
       const owner = accounts[2];
-      const roles = [1, 2];
+      const roles = [400, 500];
 
       await userFactory.setRoles2Library(roles2Library.address)
       await asserts.throws(
@@ -188,7 +200,7 @@ contract('UserFactory', function(accounts) {
 
     it('should create users with roles', async () => {
       const owner = accounts[1];
-      const roles = [1, 2];
+      const roles = [400, 500];
 
       await userFactory.setRoles2Library(roles2Library.address)
       await mock.expect(

--- a/test/userLibrary.js
+++ b/test/userLibrary.js
@@ -1145,7 +1145,7 @@ contract('UserLibrary', function(accounts) {
     });
   });
 
-  describe.only('Statistics', () => {
+  describe('Statistics', () => {
 
     const users = {
       user1: accounts[1],

--- a/test/z-integration-tests.js
+++ b/test/z-integration-tests.js
@@ -1187,7 +1187,7 @@ contract('Integration tests (user stories)', (accounts) => {
             userRecoveryAddress = contracts.recovery.address
 
             await contracts.userFactory.addAllowedRoles(userInfo.roles, { from: users.root, })
-
+            
             const recoverData = contracts.recovery.contract.recoverUser.getData(0x0, 0x0)
             await contracts.rolesLibrary.addRoleCapability(roles.moderator, contracts.recovery.address, recoverData, { from: users.contractOwner })
         })


### PR DESCRIPTION
- Downgrade smart contracts to support solc 0.4.21;
- update migrations for UserFactory set up;
- fix tests (remove 'only' modifier that prevented running all other test suites).