### PR TITLE
LABX-331 create flow for add expanse

### DIFF
--- a/common/errors.js
+++ b/common/errors.js
@@ -29,6 +29,8 @@ const errorCodes = {
     JOB_CONTROLLER_WORK_IS_NOT_PAUSED: errorScope.jobcontroller + 6,
     JOB_CONTROLLER_INVALID_WORKFLOW_TYPE: errorScope.jobcontroller + 7,
     JOB_CONTROLLER_INVALID_ROLE: errorScope.jobcontroller + 8,
+    JOB_CONTROLLER_NO_TIME_REQUEST_SUBMITTED: errorScope.jobcontroller + 9,
+    JOB_CONTROLLER_INCORRECT_TIME_PROVIDED: errorScope.jobcontroller + 10,
 
 
     PAYMENT_GATEWAY_INSUFFICIENT_BALANCE: errorScope.paymentgateway + 1,

--- a/contracts/JobDataCore.sol
+++ b/contracts/JobDataCore.sol
@@ -70,6 +70,9 @@ contract JobDataCore is StorageAdapter, BitOps {
     /// @dev Workflow type for a job
     StorageInterface.UIntUIntMapping jobWorkflowType;  // jobId => workflow type
 
+    /// @dev Requested amount of time a worker needs to complete a job
+    StorageInterface.UIntUIntMapping jobRequestedAdditionalTime; // In minutes
+
     /// @dev Default pay for a posted job that are recommended for offers
     StorageInterface.UIntUIntMapping jobDefaultPay;  // jobId => default pay size
     StorageInterface.UIntAddressUIntMapping jobOfferRate; // Per minute.
@@ -125,6 +128,7 @@ contract JobDataCore is StorageAdapter, BitOps {
         jobPausedFor.init("jobPausedFor");
 
         jobWorkflowType.init("jobWorkflowType");
+        jobRequestedAdditionalTime.init("jobRequestedTime");
         jobDefaultPay.init("jobDefaultPay");
         jobOfferRate.init("jobOfferRate");
         jobOfferEstimate.init("jobOfferEstimate");

--- a/contracts/JobsDataProvider.sol
+++ b/contracts/JobsDataProvider.sol
@@ -150,7 +150,7 @@ contract JobsDataProvider is JobDataCore {
         return store.get(jobsCount);
     }
 
-    uint8 constant JOBS_RESULT_OFFSET = 21;
+    uint8 constant JOBS_RESULT_OFFSET = 22;
 
     /// @notice Gets jobs details in an archived way (too little stack size
     /// for such amount of return values)
@@ -175,7 +175,8 @@ contract JobsDataProvider is JobDataCore {
     ///     "_pausedFor": "`uint` work's pause duration",
     ///     "_pendingFinishAt": "`uint` pending finish timestamp",
     ///     "_finishedAt": "`uint` work finished timestamp",
-    ///     "_finalizedAt": "`uint` paycheck finalized timestamp"
+    ///     "_finalizedAt": "`uint` paycheck finalized timestamp",
+    ///     "_timeRequested": "`uint` additional time requested by a worker, must be accepted/rejected by a client",
     /// }
     function getJobsByIds(uint[] _jobIds) public view returns (
         bytes32[] _results
@@ -203,6 +204,7 @@ contract JobsDataProvider is JobDataCore {
             _results[_idx * JOBS_RESULT_OFFSET + 18] = bytes32(store.get(jobPendingFinishAt, _jobIds[_idx]));
             _results[_idx * JOBS_RESULT_OFFSET + 19] = bytes32(store.get(jobFinishTime, _jobIds[_idx]));
             _results[_idx * JOBS_RESULT_OFFSET + 20] = bytes32(store.get(jobFinalizedAt, _jobIds[_idx]));
+            _results[_idx * JOBS_RESULT_OFFSET + 21] = bytes32(store.get(jobRequestedAdditionalTime, _jobIds[_idx]));
 
             if (address(_boardController) != 0x0) {
                 _results[_idx * JOBS_RESULT_OFFSET + 1] = bytes32(_boardController.getJobsBoard(_jobIds[_idx]));

--- a/contracts/helpers/Mock.sol
+++ b/contracts/helpers/Mock.sol
@@ -28,7 +28,7 @@ contract Mock {
             }
         }
         callsCount++;
-        bytes32 callHash = keccak256(msg.sender, msg.value, msg.data);
+        bytes32 callHash = keccak256(abi.encodePacked(msg.sender, msg.value, msg.data));
         if (expectations[nextExpectation].callHash != callHash) {
             emit UnexpectedCall(nextExpectation, msg.sender, msg.value, msg.data, callHash);
             assembly {
@@ -48,11 +48,15 @@ contract Mock {
     }
 
     function expect(address _from, uint _value, bytes _input, bytes32 _return) public {
-        expectations[++expectationsCount] = Expect(keccak256(_from, _value, _input), _return);
+        expectations[++expectationsCount] = Expect(keccak256(abi.encodePacked(_from, _value, _input)), _return);
     }
 
     function convertUIntToBytes32(uint _value) public pure returns (bytes32) {
         return bytes32(_value);
+    }
+
+    function convertBytes32ToUInt(bytes32 _value) public pure returns (uint) {
+        return uint(_value);
     }
 
     function convertToBytes32(bytes32 _value) public pure returns (bytes32) {

--- a/test/z-integration-tests.js
+++ b/test/z-integration-tests.js
@@ -493,15 +493,19 @@ contract('Integration tests (user stories)', (accounts) => {
 
             it("should be able to add more time for a job with OK code", async () => {
                 const additionalTime = 150;
+                await contracts.jobController.submitAdditionalTimeRequest(otherJob.id, additionalTime, { from: users.worker2, })
                 const additionalPayment = await contracts.jobController.calculateLock(users.worker2, otherJob.id, additionalTime, 0)
-                assert.equal((await contracts.jobController.addMoreTime.call(otherJob.id, additionalTime, { from: users.client, value: additionalPayment})).toNumber(), ErrorsScope.OK)
+                assert.equal(
+                    (await contracts.jobController.acceptAdditionalTimeRequest.call(otherJob.id, additionalTime, { from: users.client, value: additionalPayment, })).toNumber(), 
+                    ErrorsScope.OK
+                )
             })
 
             it("should be able to add more time for a job", async () => {
                 const additionalTime = 150;
                 const additionalPayment = await contracts.jobController.calculateLock(users.worker2, otherJob.id, additionalTime, 0)
-                const tx = await contracts.jobController.addMoreTime(otherJob.id, additionalTime, { from: users.client, value: additionalPayment})
-                const timeAddedEvent = (await eventsHelper.findEvent([contracts.jobController,], tx, "TimeAdded"))[0]
+                const tx = await contracts.jobController.acceptAdditionalTimeRequest(otherJob.id, additionalTime, { from: users.client, value: additionalPayment, })
+                const timeAddedEvent = (await eventsHelper.findEvent([contracts.jobController,], tx, "TimeRequestAccepted"))[0]
                 assert.isDefined(timeAddedEvent)
             })
 


### PR DESCRIPTION
[JIRA LABX-331](https://chronobank.atlassian.net/browse/LABX-331)

Add `submitAdditionalTimeRequest()`, `acceptAdditionalTimeRequest()` and `rejectAdditionalTimeRequest()` to customize and provide an ability to a worker to define needed time to finish a job. 
Old function `addMoreTime` is now  deprecated and removed from **JobController** contract.

Add test cases according to changes.

Fix returning sent Ether in JobController when calling `payable` functions (like `acceptOffer` or `acceptAdditionalTimeRequest`) and error code returns.